### PR TITLE
Adjust to upcoming julia 1.12 world age change

### DIFF
--- a/src/fastfunc.jl
+++ b/src/fastfunc.jl
@@ -56,7 +56,7 @@ macro fastfunc(polynomial)
 		local polystr = string($(esc(polynomial)))
 		local vars = string(tuple(variables($(esc(polynomial)))...))
         # create expression for function definition
-		eval(Meta.parse(vars*" -> @fastmath "*polystr))
+		@eval($(Expr(:$,:(Meta.parse(vars*" -> @fastmath "*polystr)))))
 	end
 end
 


### PR DESCRIPTION
Julia 1.12 will be more picky about where exactly implicit world age increments happen (see https://github.com/JuliaLang/julia/pull/56509). The `@fastfunc` macro needs one because it uses a runtime eval call. To ensure this keep working on Julia 1.12, switch the macro to invoke `@eval` macro rather than the `eval` function. The former will likely retain an implicit world age increment after its evaluation, so by making this switch `@fastfunc` will inherit this behavior.